### PR TITLE
[IR] Provide, Realize associate with per value_index

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@ The code is componetized into logical components
 - base: Basic code
 - ir: The IR data structure
 - pass: Pass functions on IR
-- codegen: Target related codgen
-
-Goal: base, ir, pass are invariant of LLVM, codegen can depend on LLVM
 
 ## Changes to Original Project
 - Codestyle: keep old files in old code style
@@ -20,28 +17,47 @@ Goal: base, ir, pass are invariant of LLVM, codegen can depend on LLVM
 - Replace implmentation of Float16.cpp with a simpler version that does not depend on LLVM
 - Removed introspection code that depends on LLVM
 - Folder ir, base now invariant of LLVM
-- Remove Parameter, BufferPtr from Variable and Call
-  - Parameter, BufferPtr could be replaced by higher level wrapping of structs that contains unbinded Variables.
-- Remove IntrusivePtr, change everything based on std::shared_ptr
+
+### Changes in IR Data Structure
+- IntrusivePtr
+  - Remove IntrusivePtr, change everything based on std::shared_ptr
   - See base/Node.h
   - Add support for IR reflection via NodeRef.VisitAttrs
   - All the IR is constructable from python via TVM
     - This enables quick proptyping and debuging from python
-- Make FunctionBaseNode abstract, to replace FunctionContent
-- Remove use of string name matching of variable and function
-  - When place where variable is needed, use VarExpr
+- Call
+  - Remove Parameter, BufferPtr from Variable and Call
+  - Parameter, BufferPtr could be replaced by higher level wrapping of new Operation(Function) variants
+- FunctionContent
+  - Make FunctionBaseNode abstract, to replace FunctionContent
+- Provide, Realize, ProducerConsumer, Call
+  - Remove use of string name matching of function
   - When place where function is needed, use FunctionRef
-  - VarExpr and FunctionRef are uniqued matched by internal pointer.
+  - FunctionRef is uniqued matched by internal pointer.
+- Variable, Store, Allocate, Free, For, Load, Let, LetStmt
+  - Remove use of string name matching of Variable
+  - When place where variable is needed, use VarExpr
+  - VarExpr is uniqued matched by internal pointer.
+- Variable
   - Rename Variable.name -> Variable.name_hint, to avoid confusion.
+  - Variable.name_hint is not used to uniquely identify the variable.
+  - When possible, encourage SSA form of IR.
+- Provide, Realize
+  - Change Provide and Realize to associate with value_index.
+  - Original Provide/Realize with multiple values can be represented by several Provide and Realize chained together
+  - This allows outputs of a Function to have different shapes.
 - Make every field the IR reflectable and accessible from python
   - std::vector<> - > Array<>(tvm/array)
   - struct Range ->  Range(Range.h)
-- Remove use of string name mapping in the Scope
-- Move div_imp, mod_imp from Simplify.h to Divmod.h to avoid cyclic include
-- Remove constructor Range(min, extent) to Range::make_with_min_extend(min, extent)
+- Range
+  - Remove constructor Range(min, extent) to Range::make_with_min_extent(min, extent)
   - The original constructor could make new user confuse since a typical way is
     range(begin, end) in both c++ and python
-- Add a more flexible RTTI and dynamic dispatch support, see src/tvm/ir_node.h
+
+### Changes in IR Pass
+- Add a more flexible RTTI and dynamic dispatch support, see src/tvm/node.h
   - IRFunctor allows plugin of new IR Node more easily, without chaning interface
+- Remove use of string name mapping in the Scope
+- Move div_imp, mod_imp from Simplify.h to Divmod.h to avoid cyclic include
 - Remove Scope in Substitute to check name conflicts because we use variable pointer matching
 - Add Expr&/Stmt& to visit interface in the IRVisitor and IRMutator

--- a/src/ir/FunctionBase.h
+++ b/src/ir/FunctionBase.h
@@ -37,7 +37,7 @@ class FunctionBaseNode : public Node {
   /*! \return the name of the function */
   virtual const std::string& func_name() const = 0;
   /*! \return the number of outputs of this function */
-  virtual int outputs() const = 0;
+  virtual int num_outputs() const = 0;
 };
 
 // implements of inline functions

--- a/src/ir/IR.cpp
+++ b/src/ir/IR.cpp
@@ -267,18 +267,18 @@ Stmt Store::make(VarExpr buffer_var, Expr value, Expr index) {
     return Stmt(node);
 }
 
-Stmt Provide::make(FunctionRef func, Array<Expr> values, Array<Expr> args) {
-    internal_assert(!values.empty()) << "Provide of no values\n";
-    for (size_t i = 0; i < values.size(); i++) {
-        internal_assert(values[i].defined()) << "Provide of undefined value\n";
-    }
+Stmt Provide::make(FunctionRef func, int value_index, Expr value, Array<Expr> args) {
+    internal_assert(value_index >=0 && value_index < func->num_outputs())
+        << "value index output function return value bound";
+    internal_assert(value.defined()) << "Provide of undefined value\n";
     for (size_t i = 0; i < args.size(); i++) {
         internal_assert(args[i].defined()) << "Provide to undefined location\n";
     }
 
     std::shared_ptr<Provide> node = std::make_shared<Provide>();
     node->func = func;
-    node->values = values;
+    node->value_index = value_index;
+    node->value = value;
     node->args = args;
     return Stmt(node);
 }
@@ -349,7 +349,8 @@ Stmt Free::make(VarExpr buffer_var) {
     return Stmt(node);
 }
 
-Stmt Realize::make(FunctionRef func, const std::vector<Type> &types, const Region &bounds, Expr condition, Stmt body) {
+Stmt Realize::make(FunctionRef func, int value_index, Type type,
+                   const Region &bounds, Expr condition, Stmt body) {
     for (size_t i = 0; i < bounds.size(); i++) {
         internal_assert(bounds[i]->min.defined()) << "Realize of undefined\n";
         internal_assert(bounds[i]->extent.defined()) << "Realize of undefined\n";
@@ -357,13 +358,13 @@ Stmt Realize::make(FunctionRef func, const std::vector<Type> &types, const Regio
         internal_assert(bounds[i]->extent.type().is_scalar()) << "Realize of vector size\n";
     }
     internal_assert(body.defined()) << "Realize of undefined\n";
-    internal_assert(!types.empty()) << "Realize has empty type\n";
     internal_assert(condition.defined()) << "Realize with undefined condition\n";
     internal_assert(condition.type().is_bool()) << "Realize condition is not boolean\n";
 
     std::shared_ptr<Realize> node = std::make_shared<Realize>();
     node->func = func;
-    node->types = types;
+    node->value_index = value_index;
+    node->type = type;
     node->bounds = bounds;
     node->condition = condition;
     node->body = body;

--- a/src/ir/IR.h
+++ b/src/ir/IR.h
@@ -450,14 +450,17 @@ struct Store : public StmtNode<Store> {
  * Store node. */
 struct Provide : public StmtNode<Provide> {
     FunctionRef func;
-    Array<Expr> values;
+    int value_index;
+    Expr value;
     Array<Expr> args;
 
-    EXPORT static Stmt make(FunctionRef func, Array<Expr> values, Array<Expr> args);
+    EXPORT static Stmt make(FunctionRef func, int value_index,
+                            Expr value, Array<Expr> args);
 
     void VisitAttrs(IR::AttrVisitor* v) final {
         v->Visit("func", &func);
-        v->Visit("values", &values);
+        v->Visit("value_index", &value_index);
+        v->Visit("value", &value);
         v->Visit("args", &args);
     }
     static const IRNodeType _type_info = IRNodeType::Provide;
@@ -534,19 +537,22 @@ struct Free : public StmtNode<Free> {
  * the condition evaluates to true. */
 struct Realize : public StmtNode<Realize> {
     FunctionRef func;
-    std::vector<Type> types;
+    int value_index;
+    Type type;
     Region bounds;
     Expr condition;
     Stmt body;
 
     EXPORT static Stmt make(FunctionRef func,
-                            const std::vector<Type> &types,
+                            int value_index,
+                            Type type,
                             const Region &bounds,
                             Expr condition, Stmt body);
 
     void VisitAttrs(IR::AttrVisitor* v) final {
         v->Visit("func", &func);
-        // v->Visit("types", &types);
+        v->Visit("value_index", &value_index);
+        v->Visit("dtype", &type);
         v->Visit("bounds", &bounds);
         v->Visit("condition", &condition);
         v->Visit("body", &body);

--- a/src/ir/IREquality.cpp
+++ b/src/ir/IREquality.cpp
@@ -90,7 +90,7 @@ private:
     void visit(const Realize *, const Stmt &);
     void visit(const Block *, const Stmt &);
     void visit(const IfThenElse *, const Stmt &);
-    void visit(const Evaluate *, const Stmt &);  
+    void visit(const Evaluate *, const Stmt &);
 };
 
 template<typename T>
@@ -393,8 +393,9 @@ void IRComparer::visit(const Provide *op, const Stmt &s) {
     const Provide *node = stmt_.as<Provide>();
 
     compare_node_refs(node->func, op->func);
+    compare_scalar(node->value_index, op->value_index);
     compare_expr_vector(node->args, op->args);
-    compare_expr_vector(node->values, op->values);
+    compare_expr(node->value, op->value);
 }
 
 void IRComparer::visit(const Allocate *op, const Stmt &s) {
@@ -412,11 +413,10 @@ void IRComparer::visit(const Realize *op, const Stmt &s) {
     const Realize *node = stmt_.as<Realize>();
 
     compare_node_refs(node->func, op->func);
-    compare_scalar(node->types.size(), op->types.size());
+    compare_scalar(node->value_index, op->value_index);
+    compare_types(node->type, op->type);
     compare_scalar(node->bounds.size(), op->bounds.size());
-    for (size_t i = 0; (result == Equal) && (i < node->types.size()); i++) {
-        compare_types(node->types[i], op->types[i]);
-    }
+
     for (size_t i = 0; (result == Equal) && (i < node->bounds.size()); i++) {
         compare_expr(node->bounds[i]->min, op->bounds[i]->min);
         compare_expr(node->bounds[i]->extent, op->bounds[i]->extent);

--- a/src/ir/IRMutator.cpp
+++ b/src/ir/IRMutator.cpp
@@ -236,7 +236,7 @@ void IRMutator::visit(const Store *op, const Stmt &s) {
 
 void IRMutator::visit(const Provide *op, const Stmt &s) {
     vector<Expr> new_args(op->args.size());
-    vector<Expr> new_values(op->values.size());
+
     bool changed = false;
 
     // Mutate the args
@@ -246,18 +246,14 @@ void IRMutator::visit(const Provide *op, const Stmt &s) {
         if (!new_arg.same_as(old_arg)) changed = true;
         new_args[i] = new_arg;
     }
-
-    for (size_t i = 0; i < op->values.size(); i++) {
-        Expr old_value = op->values[i];
-        Expr new_value = mutate(old_value);
-        if (!new_value.same_as(old_value)) changed = true;
-        new_values[i] = new_value;
-    }
+    Expr old_value = op->value;
+    Expr new_value = mutate(old_value);
+    if (!new_value.same_as(old_value)) changed = true;
 
     if (!changed) {
       stmt = s;
     } else {
-      stmt = Provide::make(op->func, new_values, new_args);
+      stmt = Provide::make(op->func, op->value_index, new_value, new_args);
     }
 }
 
@@ -311,7 +307,8 @@ void IRMutator::visit(const Realize *op, const Stmt &s) {
         condition.same_as(op->condition)) {
       stmt = s;
     } else {
-      stmt = Realize::make(op->func, op->types, new_bounds,
+      stmt = Realize::make(op->func, op->value_index,
+                           op->type, new_bounds,
                            condition, body);
     }
 }

--- a/src/ir/IRPrinter.cpp
+++ b/src/ir/IRPrinter.cpp
@@ -460,20 +460,12 @@ TVM_STATIC_IR_FUNCTOR(IRPrinter, vtable)
         p->print(op->args[i]);
         if (i < op->args.size() - 1) p->stream << ", ";
     }
-    p->stream << ") = ";
-    if (op->values.size() > 1) {
-        p->stream << "{";
+    p->stream << ")";
+    if (op->func->num_outputs() != 1) {
+      p->stream << ".value[" << op->value_index << "]";
     }
-    for (size_t i = 0; i < op->values.size(); i++) {
-        if (i > 0) {
-            p->stream << ", ";
-        }
-        p->print(op->values[i]);
-    }
-    if (op->values.size() > 1) {
-        p->stream << "}";
-    }
-
+    p->stream << " =";
+    p->print(op->value);
     p->stream << '\n';
 });
 
@@ -520,6 +512,9 @@ TVM_STATIC_IR_FUNCTOR(IRPrinter, vtable)
         if (i < op->bounds.size() - 1) p->stream << ", ";
     }
     p->stream << ")";
+    if (op->func->num_outputs() != 1) {
+      p->stream << ".value[" << op->value_index << "]";
+    }
     if (!is_one(op->condition)) {
         p->stream << " if ";
         p->print(op->condition);

--- a/src/ir/IRVisitor.cpp
+++ b/src/ir/IRVisitor.cpp
@@ -162,9 +162,7 @@ void IRVisitor::visit(const Store *op, const Stmt &) {
 }
 
 void IRVisitor::visit(const Provide *op, const Stmt &) {
-    for (size_t i = 0; i < op->values.size(); i++) {
-        op->values[i].accept(this);
-    }
+    op->value.accept(this);
     for (size_t i = 0; i < op->args.size(); i++) {
         op->args[i].accept(this);
     }
@@ -386,9 +384,7 @@ void IRGraphVisitor::visit(const Store *op, const Stmt &) {
 }
 
 void IRGraphVisitor::visit(const Provide *op, const Stmt &) {
-    for (size_t i = 0; i < op->values.size(); i++) {
-        include(op->values[i]);
-    }
+    include(op->value);
     for (size_t i = 0; i < op->args.size(); i++) {
         include(op->args[i]);
     }


### PR DESCRIPTION
 - Change Provide and Realize to associate with value_index.
- Original Provide/Realize with multiple values can be represented by several Provide and Realize chained together
 - This allows outputs of a Function to have different shapes.