### PR TITLE
Fix linker error in TOPI

### DIFF
--- a/src/ir/Expr.h
+++ b/src/ir/Expr.h
@@ -242,7 +242,7 @@ struct VarExpr : public Expr {
      * Choose first have name then type, with default int32
      * because most VarExpr are used as looping variable.
      */
-    explicit VarExpr(const std::string &name_hint, Type t = Int(32));
+    EXPORT explicit VarExpr(const std::string &name_hint, Type t = Int(32));
     /** return internal content as Variable */
     inline const Internal::Variable* get() const;
     /** return internal variable pointer */


### PR DESCRIPTION
On windows linking TOPI fails unless VarExpr constructor is marked EXPORT. This is depended on by
`tvm::Var::Var(const std::string& name_hint = "v", Type t = Int(32))`
