### PR TITLE
Remove Halide_SHARED condition from EXPORT macro on Windows

### DIFF
--- a/src/base/Util.h
+++ b/src/base/Util.h
@@ -20,7 +20,7 @@
 #include <cstring>
 
 // by default, the symbol EXPORT does nothing. In windows dll builds we can define it to __declspec(dllexport)
-#if defined(_WIN32) && defined(Halide_SHARED)
+#if defined(_WIN32)
 #ifdef Halide_EXPORTS
 #define EXPORT __declspec(dllexport)
 #else

--- a/src/ir/Expr.h
+++ b/src/ir/Expr.h
@@ -242,7 +242,7 @@ struct VarExpr : public Expr {
      * Choose first have name then type, with default int32
      * because most VarExpr are used as looping variable.
      */
-    explicit VarExpr(const std::string &name_hint, Type t = Int(32));
+    EXPORT explicit VarExpr(const std::string &name_hint, Type t = Int(32));
     /** return internal content as Variable */
     inline const Internal::Variable* get() const;
     /** return internal variable pointer */


### PR DESCRIPTION
Applying fix from this TVM issue
https://github.com/dmlc/tvm/issues/839