### PR TITLE
Add TVM_AUTO_STATIC_IR_FUNCTOR macro for auto-unregistering dispatch functions

### DIFF
--- a/src/tvm/ir_functor.h
+++ b/src/tvm/ir_functor.h
@@ -184,20 +184,20 @@ class IRFunctor<R(const NodeRef& n, Args...)> {
  * \brief A container for a list of callbacks. All callbacks are invoked when
  * the object is destructed.
  */
-class FreeList {
-private:
-  std::vector<std::function<void()>> free_list;
-
+class IRFunctorCleanList {
 public:
-  ~FreeList() {
-    for (auto &f : free_list) {
+  ~IRFunctorCleanList() {
+    for (auto &f : clean_items) {
       f();
     }
   }
 
   void append(std::function<void()> func) {
-    free_list.push_back(func);
+    clean_items.push_back(func);
   }
+
+private:
+  std::vector< std::function<void()> > clean_items;
 };
 
 /*!
@@ -216,14 +216,14 @@ template<typename R, typename ...Args>
 class IRFunctorStaticRegistry<R(const NodeRef& n, Args...)> {
 private:
   IRFunctor<R(const NodeRef& n, Args...)> *irf_;
-  std::shared_ptr<FreeList> free_list;
+  std::shared_ptr<IRFunctorCleanList> free_list;
 
   using TSelf = IRFunctorStaticRegistry<R(const NodeRef& n, Args...)>;
 
 public:
   IRFunctorStaticRegistry(IRFunctor<R(const NodeRef& n, Args...)> *irf) {
     irf_ = irf;
-    free_list = std::shared_ptr<FreeList>(new FreeList());
+    free_list = std::make_shared<IRFunctorCleanList>();
   }
 
   template<typename TNode>

--- a/src/tvm/ir_functor.h
+++ b/src/tvm/ir_functor.h
@@ -229,9 +229,9 @@ public:
   template<typename TNode>
   inline TSelf& set_dispatch(std::function<R(const TNode* n, Args...)> f) {  // NOLINT(*)
     irf_->set_dispatch<TNode>(f);
-    auto irfCopy = irf_;
-    free_list.get()->append([irfCopy] {
-      irfCopy->clear_dispatch<TNode>();
+    auto irf_copy = irf_;
+    free_list.get()->append([irf_copy] {
+      irf_copy->clear_dispatch<TNode>();
       });
     return *this;
   }


### PR DESCRIPTION
This addresses the issue raised in
https://github.com/dmlc/nnvm/issues/174
where on Windows a crash occurs when exiting if nnvm_compiler.dll has been loaded.

The solution implemented is to add a wrapper class around IRFunctor that records calls to set_dispatch and then unset them when the wrapper is disposed. Assigning the wrapper to a static variable means it will be disposed when the library is unloaded.

To apply this fix, NNVM should use TVM_AUTO_STATIC_IR_FUNCTOR instead of TVM_STATIC_IR_FUNCTOR.

Note: I am not sure how robust this fix is - I'm not familiar enough with the precise semantics of static variables, but it does fix the linked issue.

PS note that TVM_AUTO_STATIC_IR_FUNCTOR creates a static variable not a static reference like TVM_STATIC_IR_FUNCTOR. This is essential to this patch working correctly.