### PR TITLE
disable simplification for div when ic<0

### DIFF
--- a/src/arithmetic/Simplify.cpp
+++ b/src/arithmetic/Simplify.cpp
@@ -839,7 +839,9 @@ private:
                    add_a_a &&
                    const_int(add_a_a->b, &ia) &&
                    const_int(div_a->b, &ib) && ib &&
-                   const_int(b, &ic)) {
+                   const_int(b, &ic) &&
+                   // disable when ic < 0 since hardware may round up for div
+                   ic >= 0) {
             // ((a + ia) / ib + ic) -> (a + (ia + ib*ic)) / ib
             expr = mutate((add_a_a->a + IntImm::make(op->type, ia + ib*ic)) / div_a->b);
         } else if (mul_a &&


### PR DESCRIPTION
As discussed here https://discuss.tvm.ai/t/dangerous-optimization-in-simplify/913
For this simplification: ((a + ia) / ib + ic) -> (a + (ia + ib*ic)) / ib
when ic is negative, ic=-1, ib=2 and a + ia = 1
before optimization,
1/ 2 - 1 = -1
after optimization
（1 - 1 × 2） / 2 = 0
comes out different result, if hardware round up differently for 1/2 and -1/2
for some hardware, round up like, 1/2=0 -1/2=0

So we disable when ic < 0