### PR TITLE
[dynamic shape runtime] bounded_var

### DIFF
--- a/src/ir/IR.cpp
+++ b/src/ir/IR.cpp
@@ -481,6 +481,15 @@ VarExpr Variable::make(Type type, std::string name_hint) {
     NodePtr<Variable> node = make_node<Variable>();
     node->type = type;
     node->name_hint = std::move(name_hint);
+    node->upper_bound = -1;
+    return VarExpr(node);
+}
+
+VarExpr Variable::make_bounded(Type type, std::string name_hint, int upper_bound) {
+    NodePtr<Variable> node = make_node<Variable>();
+    node->type = type;
+    node->name_hint = std::move(name_hint);
+    node->upper_bound = upper_bound;
     return VarExpr(node);
 }
 

--- a/src/ir/IR.h
+++ b/src/ir/IR.h
@@ -797,6 +797,11 @@ struct Variable : public ExprNode<Variable> {
      */
     std::string name_hint;
 
+    /*
+     * Hint for upper bound. -1 for conventional variable
+     */
+    int64_t upper_bound;
+
     // BufferPtr and Parameter are removed from IR
     // They can be added back via passing in binding of Variable to specific values.
     // in the final stage of code generation.
@@ -806,10 +811,12 @@ struct Variable : public ExprNode<Variable> {
     // instead,uses Reduction as a ExprNode
 
     EXPORT static VarExpr make(Type type, std::string name_hint);
+    EXPORT static VarExpr make_bounded(Type type, std::string name_hint, int upper_bound);
 
     void VisitAttrs(IR::AttrVisitor* v) final {
         v->Visit("dtype", &type);
         v->Visit("name", &name_hint);
+        v->Visit("upper_bound", &upper_bound);
     }
     static const IRNodeType _type_info = IRNodeType::Variable;
     static constexpr const char* _type_key = "Variable";

--- a/src/ir/IR.h
+++ b/src/ir/IR.h
@@ -800,7 +800,7 @@ struct Variable : public ExprNode<Variable> {
     /*
      * Hint for upper bound. -1 for conventional variable
      */
-    int64_t upper_bound;
+    int32_t upper_bound;
 
     // BufferPtr and Parameter are removed from IR
     // They can be added back via passing in binding of Variable to specific values.


### PR DESCRIPTION
In order to support symbolic shape runtime in Relay, bounded_var is added for memory planing. bounded_var provides an attribute ```upper_bound```, which is a hint for planing an upper bounded for a dimension in symbolic shape.

Sample runtime code:
```
import tvm
from tvm import relay


x = relay.var("x",
              shape=[tvm.bounded_var("n1", upper_bound=128),
                     4,
                     2, 3], dtype="float32")
y = relay.var("y",
              shape=[tvm.bounded_var("n2", upper_bound=32),
                     4,
                     2, 3], dtype="float32")

z = relay.op.tensor.concatenate([x, y], axis=0)


a = relay.var("a",
              shape=[tvm.bounded_var("n3", upper_bound=12),
                     4,
                     2, 3], dtype="float32")
b = relay.var("b",
              shape=[27,
                     4,
                     2, 3], dtype="float32")

c = relay.op.tensor.concatenate([a, b], axis=0)

out = relay.op.tensor.concatenate([z, c], axis=0)

func = relay.Function([x, y, a, b], out)


graph, mod, param = relay.build_module.build(func, target="llvm")

# print(graph)
rt = tvm.contrib.graph_runtime.create(graph, mod, tvm.cpu())


#### Test
def test(n1, n2, n3):
       import numpy as np
       vars = {
              "n1": n1,
              "n2": n2,
              "n3": n3
       }
       shapes = {
              "x": (n1, 4, 2, 3),
              "y": (n2, 4, 2, 3),
              "a": (n3, 4, 2, 3),
              "b": (27, 4, 2, 3)
       }
       arrays = {
              "x": np.random.uniform(-1, 1, shapes["x"]).astype("float32"),
              "y": np.random.uniform(-1, 1, shapes["y"]).astype("float32"),
              "a": np.random.uniform(-1, 1, shapes["a"]).astype("float32"),
              "b": np.random.uniform(-1, 1, shapes["b"]).astype("float32"),
       }
       inputs = {k:tvm.nd.array(v) for k, v in arrays.items()}
 
       z = np.vstack((arrays["x"], arrays["y"]))
       c = np.vstack((arrays["a"], arrays["b"]))
       ans = np.vstack((z, c))
       rt.set_shape_variable(vars)
       rt.set_input(**inputs)
       rt.run()
       out = rt.get_output(0).asnumpy()
       np.testing.assert_allclose(ans, out, rtol=1e-5, atol=1e-5)

test(1, 2, 3)
test(30, 20, 10)
test(5, 7, 9)
```
       
