### PR TITLE
Cleanup exported symbol visibility to optimize shared library modules.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DMLC_CORE_PATH ?= ../dmlc-core
 LDFLAGS = -pthread -lm
 CFLAGS =  -std=c++11 -Wall -O2\
-	 -Iinclude -I${DMLC_CORE_PATH}/include -I../include -I../dlpack/include -Isrc -fPIC
+	 -Iinclude -I${DMLC_CORE_PATH}/include -I../include -I../dlpack/include -Isrc -fPIC -fvisibility=hidden
 
 ifdef no_rtti
 	CFLAGS += -fno-rtti

--- a/src/base/Util.h
+++ b/src/base/Util.h
@@ -27,7 +27,7 @@
 #define EXPORT __declspec(dllimport)
 #endif
 #else
-#define EXPORT
+#define EXPORT __attribute__((visibility("default")))
 #endif
 
 // If we're in user code, we don't want certain functions to be inlined.

--- a/src/ir/IR.cpp
+++ b/src/ir/IR.cpp
@@ -650,8 +650,8 @@ template<> void ExprNode<Sub>::accept(IRVisitor *v, const Expr &e) const { v->vi
 template<> void ExprNode<Mul>::accept(IRVisitor *v, const Expr &e) const { v->visit((const Mul *)this, e); }
 template<> void ExprNode<Div>::accept(IRVisitor *v, const Expr &e) const { v->visit((const Div *)this, e); }
 template<> void ExprNode<Mod>::accept(IRVisitor *v, const Expr &e) const { v->visit((const Mod *)this, e); }
-template<> void ExprNode<Min>::accept(IRVisitor *v, const Expr &e) const { v->visit((const Min *)this, e); }
-template<> void ExprNode<Max>::accept(IRVisitor *v, const Expr &e) const { v->visit((const Max *)this, e); }
+template<> EXPORT void ExprNode<Min>::accept(IRVisitor *v, const Expr &e) const { v->visit((const Min *)this, e); }
+template<> EXPORT void ExprNode<Max>::accept(IRVisitor *v, const Expr &e) const { v->visit((const Max *)this, e); }
 template<> void ExprNode<EQ>::accept(IRVisitor *v, const Expr &e) const { v->visit((const EQ *)this, e); }
 template<> void ExprNode<NE>::accept(IRVisitor *v, const Expr &e) const { v->visit((const NE *)this, e); }
 template<> void ExprNode<LT>::accept(IRVisitor *v, const Expr &e) const { v->visit((const LT *)this, e); }


### PR DESCRIPTION
By default, compilation of Linux shared library modules (*.so files)
exports all symbols. This creates large module files as the export
symbol tables contains too many entries. The correct approach is
export nothing by default and anything that needs to be exported
must be explicitly specified. This is accomplished by the following
steps:

1. In the Makefile, add "-fvisibility=hidden" flag. You can search
   for "-fPIC" to find the appropriate place to add the flag. This
   hides symbols by default if not explicitly specified otherwise.

2. To declaration of any symbol to be exported, add this attribute:
      __attribute__((visibility("default")))
   The attribute string can be added using a macro definition. It
   should be added right before the return type for functions, or
   right after the 'class' or 'struct' keyword for class/struct.

For more info on shared module export symbol visibility read:
    http://anadoxin.org/blog/control-over-symbol-exports-in-gcc.html