### PR TITLE
Clang disable UBSAN

### DIFF
--- a/src/ir/IR.cpp
+++ b/src/ir/IR.cpp
@@ -22,6 +22,9 @@ EXPORT VarExpr::VarExpr(const std::string &name_hint,  Type t)
 
 namespace Internal {
 
+#if defined(__clang__)
+__attribute__((no_sanitize("undefined")))
+#endif
 EXPORT Expr IntImm::make(Type t, int64_t value) {
     internal_assert(t.is_int() && t.is_scalar())
         << "IntImm must be a scalar Int\n";


### PR DESCRIPTION
We have a test that failed because of this error, which can simply be fixed by disable UBSAN on clang. The error messages are:

```
tvm/tvm/3rdparty/HalideIR/src/ir/IR.cpp:32:11: runtime error: left shift of negative value -1
    #0 0x7faee83cb4a6 in HalideIR::Internal::IntImm::make(HalideIR::Type, long) tvm/tvm/3rdparty/HalideIR/src/ir/IR.cpp:32
    #1 0x7faee82a15cb in HalideIR::Internal::Simplify::visit(HalideIR::Internal::Sub const*, HalideIR::Expr const&) tvm/tvm/3rdparty/HalideIR/src/arithmetic/Simplify.cpp:1005
    #2 0x7faee83ed2fd in HalideIR::Internal::ExprNode<HalideIR::Internal::Sub>::accept(HalideIR::Internal::IRVisitor*, HalideIR::Expr const&) const tvm/tvm/3rdparty/HalideIR/src/ir/IR.cpp:649
    #3 0x7faee81965bd in HalideIR::Expr::accept(HalideIR::Internal::IRVisitor*) const tvm/tvm/3rdparty/HalideIR/src/ir/Expr.h:205
    #4 0x7faee840e3bb in HalideIR::Internal::IRMutator::mutate(HalideIR::Expr) tvm/tvm/3rdparty/HalideIR/src/ir/IRMutator.cpp:10
    #5 0x7faee82bc071 in HalideIR::Internal::Simplify::visit(HalideIR::Internal::Div const*, HalideIR::Expr const&) tvm/tvm/3rdparty/HalideIR/src/arithmetic/Simplify.cpp:1527
    #6 0x7faee83ed43d in HalideIR::Internal::ExprNode<HalideIR::Internal::Div>::accept(HalideIR::Internal::IRVisitor*, HalideIR::Expr const&) const tvm/tvm/3rdparty/HalideIR/src/ir/IR.cpp:651
    #7 0x7faee81965bd in HalideIR::Expr::accept(HalideIR::Internal::IRVisitor*) const tvm/tvm/3rdparty/HalideIR/src/ir/Expr.h:205
    #8 0x7faee840e3bb in HalideIR::Internal::IRMutator::mutate(HalideIR::Expr) tvm/tvm/3rdparty/HalideIR/src/ir/IRMutator.cpp:10
    #9 0x7faee81b0929 in HalideIR::Internal::simplify(HalideIR::Expr, bool, HalideIR::Internal::Scope<HalideIR::Internal::Interval> const&, HalideIR::Internal::Scope<HalideIR::Internal::ModulusRemainder> const&) tvm/tvm/3rdparty/HalideIR/src/arithmetic/Simplify.cpp:4933
    #10 0x7faee8875bf6 in HalideIR::Expr tvm::ir::Simplify_<HalideIR::Expr>(HalideIR::Expr, tvm::Map<tvm::Var, tvm::Range, void, void>) tvm/tvm/src/arithmetic/canonical.cc:780
    #11 0x7faee8873e26 in tvm::ir::Simplify(HalideIR::Expr, tvm::Map<tvm::Var, tvm::Range, void, void>) tvm/tvm/src/arithmetic/canonical.cc:929
    #12 0x7faee9b1c3c5 in tvm::schedule::DivCeil(HalideIR::Expr, HalideIR::Expr) tvm/tvm/src/schedule/message_passing.cc:20
    #13 0x7faee9b1a962 in tvm::schedule::PassDownDomain(tvm::Stage const&, std::unordered_map<tvm::IterVar, tvm::Range, std::hash<tvm::IterVar>, std::equal_to<tvm::IterVar>, std::allocator<std::pair<tvm::IterVar const, tvm::Range> > >*, bool) tvm/tvm/src/schedule/message_passing.cc:61
    #14 0x7faee9ad76de in tvm::schedule::InferBound(tvm::Schedule const&) tvm/tvm/src/schedule/bound.cc:218
    #15 0x7faee89ddaf3 in tvm::BuildStmt(tvm::Schedule, tvm::Array<tvm::Tensor, void> const&, std::unordered_map<tvm::Tensor, tvm::Buffer, std::hash<tvm::Tensor>, std::equal_to<tvm::Tensor>, std::allocator<std::pair<tvm::Tensor const, tvm::Buffer> > > const&, bool, tvm::Array<tvm::NodeRef, void>*, tvm::BuildConfig const&) tvm/tvm/src/codegen/build_module.cc:362
    #16 0x7faee89dfa48 in tvm::lower(tvm::Schedule, tvm::Array<tvm::Tensor, void> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::unordered_map<tvm::Tensor, tvm::Buffer, std::hash<tvm::Tensor>, std::equal_to<tvm::Tensor>, std::allocator<std::pair<tvm::Tensor const, tvm::Buffer> > > const&, tvm::BuildConfig const&) tvm/tvm/src/codegen/build_module.cc:400
    #17 0x43043d in compileSharedLibrary(tvm::Schedule const&, tvm::Array<tvm::Tensor, void> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) caffe2/caffe2/fb/tvm/tvm_op_test.cc:29
    #18 0x43bf9b in TVMOpTest_OpIntegration_Test::TestBody() caffe2/caffe2/fb/tvm/tvm_op_test.cc:152
    #19 0x7faed7a276e1 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/engshare/third-party2/googletest/master/src/googletest/googletest/src/gtest.cc:2458
    #20 0x7faed7a18c01 in testing::Test::Run() /home/engshare/third-party2/googletest/master/src/googletest/googletest/src/gtest.cc:2475
    #21 0x7faed7a18d47 in testing::TestInfo::Run() /home/engshare/third-party2/googletest/master/src/googletest/googletest/src/gtest.cc:2656
    #22 0x7faed7a18e54 in testing::TestCase::Run() /home/engshare/third-party2/googletest/master/src/googletest/googletest/src/gtest.cc:2776
    #23 0x7faed7a1abab in testing::internal::UnitTestImpl::RunAllTests() /home/engshare/third-party2/googletest/master/src/googletest/googletest/src/gtest.cc:4651
    #24 0x7faed7a1af64 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/engshare/third-party2/googletest/master/src/googletest/googletest/src/gtest.cc:2458
    #25 0x7faed7a1af64 in testing::UnitTest::Run() /home/engshare/third-party2/googletest/master/src/googletest/googletest/src/gtest.cc:4259
    #26 0x7faef50e8440 in RUN_ALL_TESTS() third-party-buck/gcc-5-glibc-2.23/build/googletest/include/gtest/gtest.h:2233
    #27 0x7faef50e8319 in main common/gtest/LightMain.cpp:19
    #28 0x7faec8948857 in __libc_start_main /home/engshare/third-party2/glibc/2.23/src/glibc-2.23/csu/libc-start.c:289
    #29 0x42f1d8 in _start /home/engshare/third-party2/glibc/2.23/src/glibc-2.23/sysdeps/x86_64/start.S:118

SUMMARY: UndefinedBehaviorSanitizer: invalid-shift-base tvm/tvm/3rdparty/HalideIR/src/ir/IR.cpp:32:11 in
```
