### PR TITLE
Fix failing simplifications

### DIFF
--- a/src/arithmetic/Simplify.cpp
+++ b/src/arithmetic/Simplify.cpp
@@ -4133,7 +4133,7 @@ private:
                         new_args.push_back(string(buf));
                     }
                     changed = true;
-                } else if (last && float_imm) {
+                } else if (float_imm) {
                     snprintf(buf, sizeof(buf), "%f", float_imm->value);
                     if (last) {
                         new_args.back() = last->value + buf;

--- a/src/ir/IREquality.h
+++ b/src/ir/IREquality.h
@@ -63,8 +63,7 @@ public:
         }
     }
 
-    IRCompareCache() {}
-    IRCompareCache(int b) : bits(b), entries(static_cast<size_t>(1) << bits) {}
+    IRCompareCache(int b = 8) : bits(b), entries(static_cast<size_t>(1) << bits) {}
 };
 
 /** A wrapper about Exprs so that they can be deeply compared with a


### PR DESCRIPTION
Due to a copy-paste error, two (or three, but I wasn't able to confirm the third) simplifications in `Simplify.cpp` didn't fire.