### PR TITLE
Node hierarchy codegen

### DIFF
--- a/codegen/__init__.py
+++ b/codegen/__init__.py
@@ -1,0 +1,3 @@
+'''Codegen module for the node heirarchy.'''
+
+from . import generators

--- a/codegen/dsl.py
+++ b/codegen/dsl.py
@@ -1,0 +1,66 @@
+'''DSL to define a node heirarchy for an IR.'''
+from typing import List, Dict, Any
+
+class GenType:
+    '''Any type that requires codegen.'''
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+class Primitive(GenType):
+    '''A primitive.'''
+    def __init__(self, name):
+        self.name = name
+
+int64 = Primitive('int64_t')
+uint64 = Primitive('uint64_t')
+double = float64 = Primitive('double')
+string = Primitive('string')
+
+class Attr:
+    def __init__(self, name: str, type: GenType, doc: str = '') -> None:
+        self.name = name
+        self.type = type
+        self.doc = doc
+
+class Node(GenType):
+    def __init__(self, name: str, type_key: str, doc: str = '') -> None:
+        self.name = name
+        self.type_key = type_key
+        self.doc = doc
+        self.attrs: List[Attr] = []
+
+    def attr(self, name: str, type: GenType, doc: str = '') -> 'Node':
+        if any(attr.name == name for attr in self.attrs):
+            raise LookupError(f'Node type {self.name} already has an attribute named {name}')
+
+        self.attrs.append(Attr(name, type, doc))
+
+        return self
+
+class API:
+    def __init__(self, doc: str = '') -> None:
+        self.doc = doc
+        self.entries: List[Node] = []
+    
+    def __enter__(self) -> 'API':
+        _set_api(self)
+        return self
+
+    def __exit__(self, a, b, c):
+        global _default
+        _set_api(_default)
+    
+_default = API()
+_cur_api: API = _default
+def _set_api(api: API):
+    global _cur_api
+    _cur_api = api
+def _get_api() -> API:
+    global _cur_api
+    return _cur_api
+
+def node(name: str, type_key: str, doc: str = '') -> Node:
+    result = Node(name, type_key, doc)
+    _get_api().entries.append(result)
+    return result
+

--- a/codegen/formatting.py
+++ b/codegen/formatting.py
@@ -1,0 +1,46 @@
+import io
+
+class Formatter:
+    def __init__(self) -> None:
+        self._prefix = ''
+        self._buf = io.StringIO()
+        self._last = '\n'
+
+    def prefix(self, prefix: str) -> '_Prefix':
+        return _Prefix(self, prefix)
+    
+    def indent(self, amount: int) -> '_Prefix':
+        return _Prefix(self, ' ' * amount)
+
+    def write(self, value: str):
+        if value == '':
+            return
+
+        if self._last == '\n':
+            self._buf.write(self._prefix)
+
+        self._buf.write(value[:-1].replace('\n', '\n' + self._prefix))
+        self._buf.write(value[-1])
+        self._last = value[-1]
+
+    def writeln(self, value: str = ''):
+        self.write(value + '\n')
+
+    
+    def __repr__(self):
+        return self._buf.getvalue()
+
+    def __str__(self):
+        return self._buf.getvalue()
+
+class _Prefix:
+    def __init__(self, f: Formatter, prefix: str) -> None:
+        self.f = f
+        self.prefix = prefix
+
+    def __enter__(self):
+        self.f._prefix += self.prefix
+    
+    def __exit__(self, a, b, c):
+        self.f._prefix = self.f._prefix[:-len(self.prefix)]
+

--- a/codegen/generators/__init__.py
+++ b/codegen/generators/__init__.py
@@ -1,0 +1,3 @@
+'''Generators for various languages.'''
+
+from . import cpp, cython, python

--- a/codegen/generators/cpp.py
+++ b/codegen/generators/cpp.py
@@ -1,0 +1,46 @@
+'''C++ code generator for node heirarchy.'''
+
+from .. import formatting, dsl, generators
+
+def generate(api: dsl.API):
+    result = formatting.Formatter()
+    with result.prefix('/// '):
+        result.writeln(api.doc)
+
+    for entry in api.entries:
+
+        result.writeln()
+
+        if entry.doc:
+            with result.prefix('/// '):
+                result.writeln(entry.doc)
+
+        result.writeln(f'class {entry.name}Node {{')
+        result.writeln(f'public:')
+
+        with result.indent(2):
+            for attr in entry.attrs:
+
+                if attr.doc:
+                    with result.prefix('/// '):
+                        result.writeln(attr.doc)
+
+                result.writeln(f'{type_name(attr.type)} {attr.name};')
+        
+        result.writeln(f'}}')
+        result.writeln(f'class {entry.name}: NodeRef<{entry.name}Node> {{}}')
+
+
+    return result
+
+def type_name(t: dsl.GenType) -> str:
+    if t == dsl.int64:
+        return 'int64_t'
+    if t == dsl.uint64:
+        return 'uint64_t'
+    if t == dsl.string:
+        return 'std::string'
+    elif isinstance(t, dsl.Node):
+        return t.name
+    else:
+        raise Exception(f'No c++ translation for: {t}')

--- a/codegen/generators/cython.py
+++ b/codegen/generators/cython.py
@@ -1,0 +1,1 @@
+'''Cython code generator for node heirarchy.'''

--- a/codegen/generators/python.py
+++ b/codegen/generators/python.py
@@ -1,0 +1,1 @@
+'''Python code generator for node heirarchy.'''

--- a/codegen_test.py
+++ b/codegen_test.py
@@ -1,0 +1,13 @@
+from codegen.dsl import *
+from codegen.generators import cpp
+
+with API('Test API.') as api:
+    Color = node('Color', '_color', 'A color.') \
+        .attr('r', int64) \
+        .attr('g', int64) \
+        .attr('b', int64) \
+
+    Apple = node('Apple', '_apple', 'A scrumptious apple.') \
+        .attr('color', Color)
+
+print(str(cpp.generate(api)))


### PR DESCRIPTION
Starting to implement codegen for the node hierarchy discussed in https://github.com/dmlc/tvm/issues/2983.

My current test script:
```python
from codegen.dsl import *
from codegen.generators import cpp

with API('Test API.') as api:
    Color = node('Color', '_color', 'A color.') \
        .attr('r', int64) \
        .attr('g', int64) \
        .attr('b', int64)

    Apple = node('Apple', '_apple', 'A scrumptious apple.') \
        .attr('color', Color)

print(str(cpp.generate(api)))
```

Output from the test script (incorrect, but illustrative):
```cpp
/// Test API.

/// A color.
class ColorNode {
public:
  int64_t r;
  int64_t g;
  int64_t b;
}
class Color: NodeRef<ColorNode> {}

/// A scrumptious apple.
class AppleNode {
public:
  Color color;
}
class Apple: NodeRef<AppleNode> {}
```

TODO:

- [ ] decide on any updates to the Node API / other semantics we want to change
- [ ] create generators for each of the languages we want to auto-generate nodes for
- [ ] create hierarchy definitions for each Node hierarchy (Halide, Relay, ?)
- [ ] run generation scripts during build
- [ ] set up CI to mypy+lint generation scripts
- [ ] set up CI to make sure generated code is checked in (if we want to check it in)
- [ ] pass existing python tests without any code changes

cc @tqchen @jroesch @junrushao1994 