### PR TITLE
Remove restriction on FloatImm type

### DIFF
--- a/src/ir/IR.cpp
+++ b/src/ir/IR.cpp
@@ -59,8 +59,8 @@ EXPORT Expr UIntImm::make(Type t, uint64_t value) {
 }
 
 EXPORT Expr FloatImm::make(Type t, double value) {
-  internal_assert(t.is_float() && t.is_scalar())
-      << "FloatImm must be a scalar Float\n";
+  internal_assert(t.is_scalar())
+      << "FloatImm must be a scalar\n";
   NodePtr<FloatImm> node = make_node<FloatImm>();
   node->type = t;
   switch (t.bits()) {


### PR DESCRIPTION
This is needed for the custom datatypes work on TVM. Immediates of
custom datatypes are stored as FloatImms. Currently, however, FloatImm
does not allow for non-float types to be created.

See [https://github.com/dmlc/tvm/pull/2900](https://github.com/dmlc/tvm/pull/2900). 

