### PR TITLE
Add new_expr and free_function to Realize

### DIFF
--- a/src/ir/IR.cpp
+++ b/src/ir/IR.cpp
@@ -374,7 +374,8 @@ Stmt Free::make(VarExpr buffer_var) {
 }
 
 Stmt Realize::make(FunctionRef func, int value_index, Type type,
-                   Region bounds, Expr condition, Stmt body) {
+                   Region bounds, Expr condition, Stmt body,
+                   Expr new_expr, std::string free_function) {
     for (size_t i = 0; i < bounds.size(); i++) {
         internal_assert(bounds[i]->min.defined()) << "Realize of undefined\n";
         internal_assert(bounds[i]->extent.defined()) << "Realize of undefined\n";
@@ -390,6 +391,8 @@ Stmt Realize::make(FunctionRef func, int value_index, Type type,
     node->value_index = value_index;
     node->type = type;
     node->bounds = std::move(bounds);
+    node->new_expr = std::move(new_expr);
+    node->free_function = free_function;
     node->condition = std::move(condition);
     node->body = std::move(body);
     return Stmt(node);

--- a/src/ir/IR.h
+++ b/src/ir/IR.h
@@ -587,13 +587,16 @@ struct Realize : public StmtNode<Realize> {
     Type type;
     Region bounds;
     Expr condition;
+    Expr new_expr;
+    std::string free_function;
     Stmt body;
 
     EXPORT static Stmt make(FunctionRef func,
                             int value_index,
                             Type type,
                             Region bounds,
-                            Expr condition, Stmt body);
+                            Expr condition, Stmt body,
+                            Expr new_expr = Expr(), std::string free_function = std::string());
 
     void VisitAttrs(IR::AttrVisitor* v) final {
         v->Visit("func", &func);
@@ -601,6 +604,8 @@ struct Realize : public StmtNode<Realize> {
         v->Visit("dtype", &type);
         v->Visit("bounds", &bounds);
         v->Visit("condition", &condition);
+        v->Visit("new_expr", &new_expr);
+        v->Visit("free_function", &free_function);
         v->Visit("body", &body);
     }
     static const IRNodeType _type_info = IRNodeType::Realize;


### PR DESCRIPTION
"Allocate" has new_expr and free_function, but "Realize" doesn't.

They will be used in our TensorCore IR Passes, which are applied before StorageFaltten and try to set new_expr for some buffer allocations. Before StorageFaltten, buffer allocation is represented by "Realize" instead of "Allocate", that's why we need to add them to "Realize" too.

We plan to open the TVM PR for TensorCore IR Passes in 1 or 2 days. It will be very helpful for reviewers or others to try out the TensorCore IR Passes if this PR can be merged before that. Thank you!