### PR TITLE
Fix broken lock guard

### DIFF
--- a/src/tvm/node/node.cpp
+++ b/src/tvm/node/node.cpp
@@ -36,7 +36,7 @@ EXPORT const bool Node::_DerivedFrom(uint32_t tid) const {
 // this is slow, usually caller always hold the result in a static variable.
 EXPORT uint32_t Node::TypeKey2Index(const char* key) {
   TypeManager *t = TypeManager::Global();
-  std::lock_guard<std::mutex>(t->mutex);
+  std::lock_guard<std::mutex> lock(t->mutex);
   std::string skey = key;
   auto it = t->key2index.find(skey);
   if (it != t->key2index.end()) {
@@ -50,7 +50,7 @@ EXPORT uint32_t Node::TypeKey2Index(const char* key) {
 
 EXPORT const char* Node::TypeIndex2Key(uint32_t index) {
   TypeManager *t = TypeManager::Global();
-  std::lock_guard<std::mutex>(t->mutex);
+  std::lock_guard<std::mutex> lock(t->mutex);
   internal_assert(index != 0);
   return t->index2key.at(index - 1).c_str();
 }


### PR DESCRIPTION
This commit fixes a bug where the lock guard (for concurrently accessing
the same scope from different threads) had basically no effect, due to
being bound to a temporary only.